### PR TITLE
Install client certs into user's directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,6 @@ The following packages should already be installed on the target host:
 Role Variables
 --------------
 
-dds_system_tmp
-> Path to temporary file space. Defaults to '/tmp'.
-
 dds_country
 > Two character country abbreviation. Used in the server CSR. Defaults to 'US'. 
 
@@ -53,8 +50,10 @@ dds_locality
 dds_organization
 > Organization or company name. Used in the server CSR. Defaults to 'Acme Corp'.
 
-dds_host 
-> The host name or IP address used to access the Docker daemon. Defaults to '127.0.0.1'.
+dds_host
+> The IP address used to access the Docker daemon. Defaults to
+> ansible_default_ipv4.address if available (i.e. gather_facts is not off),
+> and 127.0.0.1 otherwise.
 
 dds_passphrase
 > A password used to secure key files. Defauts to 'Phrase123!'.
@@ -81,16 +80,20 @@ Example Playbook
 
 Here's an example playbook that executes our role:
 
-    - name: Secure the docker daemon
-      hosts: localhost
-      connection: local
-      gather_facts: no
-      become: yes
-      roles:
-        - role: ansible.secure-docker-daemon
-          dds_host: 10.0.2.15
-          dds_server_cert_path: /etc/default/docker
-          dds_restart_docker: no
+```
+- name: Secure the docker daemon
+  hosts: localhost
+  connection: local
+
+  roles:
+    - role: ansible.secure-docker-daemon
+      dds_host: 10.0.2.15
+      dds_server_cert_path: /etc/default/docker
+      dds_restart_docker: no
+```
+
+Because the role requires `become` for the server certs but user privileges for
+the client certs, you may need to provide the `-K/--ask-become-pass` argument
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ dds_organization
 
 dds_host
 > The IP address used to access the Docker daemon. Defaults to
-> ansible_default_ipv4.address if available (i.e. gather_facts is not off),
+> ansible_docker0.ipv4.address if available (i.e. gather_facts is not off),
 > and 127.0.0.1 otherwise.
 
 dds_passphrase

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ dds_country: US
 dds_state: North Carolina
 dds_locality: Durham
 dds_organization: Acme Corp
-dds_host: "{{ ansible_default_ipv4.address|default('127.0.0.1') }}"
+dds_host: "{{ ansible_docker0.ipv4.address|default('127.0.0.1') }}"
 dds_common_name: "{{ dds_host }}" 
 dds_passphrase: Phrase123!
 dds_server_cert_path: /etc/docker

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,14 +1,14 @@
 ---
-dds_system_tmp: /tmp
 dds_country: US
 dds_state: North Carolina
 dds_locality: Durham
 dds_organization: Acme Corp
-dds_host: 127.0.0.1
+dds_host: "{{ ansible_default_ipv4.address|default('127.0.0.1') }}"
 dds_common_name: "{{ dds_host }}" 
 dds_passphrase: Phrase123!
 dds_server_cert_path: /etc/docker
-dds_client_cert_path: ~/.docker
-dds_env_shell_path: "~"  
+dds_user_home_dir: "{{ lookup('env', 'HOME') }}"
+dds_env_shell_path: "{{ dds_user_home_dir }}"
+dds_client_cert_path: "{{ dds_user_home_dir }}/.docker"
 dds_install_shell: yes
-dds_restart_docker: no 
+dds_restart_docker: no

--- a/tasks/generate_client_certs.yml
+++ b/tasks/generate_client_certs.yml
@@ -1,46 +1,39 @@
 # generate_client_certs.yml
 
+- name: Install CA pem file
+  copy:
+    content: "{{ dds_ca_pem.stdout }}"
+    dest: "{{ dds_client_cert_path }}/ca.pem"
+
 - name: Create client key
-  command: "openssl genrsa -out {{ dds_temp_path }}/key.pem 4096"
+  command: "openssl genrsa -out {{ dds_client_cert_path }}/key.pem 4096"
 
-- name: Create client CSR 
-  command: "openssl req -subj '/CN=client' -new -key {{ dds_temp_path}}/key.pem -out {{ dds_temp_path }}/client.csr"
-
-- name: Remove extfile
-  file:
-    state: absent
-    path: "{{ dds_extfile }}"
+- name: Create client CSR
+  command: "openssl req -subj '/CN=client' -new -key {{ dds_client_cert_path }}/key.pem -out {{ dds_client_cert_path }}/client.csr"
 
 - name: Create extfile
-  file:
-    state: touch
-    path: "{{ dds_extfile }}"
+  copy:
+    content: "extendedKeyUsage = clientAuth"
+    dest: "{{ dds_client_cert_path }}/extfile.cnf"
 
-- name: Add extendedKeyUsage to extfile
-  lineinfile:
-    dest: "{{ dds_extfile }}"
-    line: "extendedKeyUsage = clientAuth"
+- name: Create the client certificate
+  command: "openssl x509 -req -days 365 -sha256 -in {{ dds_client_cert_path }}/client.csr -CA {{ dds_client_cert_path }}/ca.pem -CAkey {{ dds_client_cert_path }}/ca-key.pem -CAcreateserial -out {{ dds_client_cert_path }}/cert.pem -extfile {{ dds_client_cert_path }}/extfile.cnf -passin env:PASSKEY"
+  environment:
+    PASSKEY: "{{ dds_passphrase }}"
 
-- name: Create the client certificate 
-  command: "openssl x509 -req -days 365 -sha256 -in {{ dds_temp_path }}/client.csr -CA {{ dds_temp_path }}/ca.pem -CAkey {{ dds_temp_path }}/ca-key.pem -CAcreateserial -out {{ dds_temp_path }}/cert.pem -extfile {{ dds_extfile }} -passin file:{{ dds_passphrase_file }}"
-
-- name: Check that the client cert path exists
-  file:
-    state: directory
-    path: "{{ dds_client_cert_path }}"
-
-- name: Copy client certs
-  command: cp "{{ dds_temp_path }}/{{ item }}" "{{ dds_client_cert_path }}/."
-  with_items:
-    - ca.pem
-    - cert.pem
-    - key.pem
-
-- name: Set file permissions 
+- name: Set file permissions
   file:
     path: "{{ dds_client_cert_path }}/{{ item }}"
-    mode: 0444
+    mode: 0600
   with_items:
     - ca.pem
     - cert.pem
     - key.pem
+
+- name: Remove unneeded temp files
+  file:
+    state: absent
+    name: "{{ dds_client_cert_path }}/{{ item }}"
+  with_items:
+  - extfile.cnf
+  - client.csr

--- a/tasks/generate_server_certs.yml
+++ b/tasks/generate_server_certs.yml
@@ -1,42 +1,27 @@
 # generate_server_certs.yml 
 
+- name: Install CA pem file
+  copy:
+    content: "{{ dds_ca_pem.stdout }}"
+    dest: "{{ dds_server_cert_path }}/ca.pem"
+
 - name: Create server key
-  command: openssl genrsa -out {{ dds_temp_path }}/server-key.pem 4096
+  command: openssl genrsa -out {{ dds_server_cert_path }}/server-key.pem 4096
 
-- name: Create the server CSR 
-  command: "openssl req -subj '/CN={{ dds_host }}' -sha256 -new -key {{ dds_temp_path }}/server-key.pem -out {{ dds_temp_path }}/server.csr"
-
-- name: Remove extfile
-  file:
-    state: absent
-    path: "{{ dds_extfile }}" 
+- name: Create the server CSR
+  command: "openssl req -subj '/CN={{ dds_host }}' -sha256 -new -key {{ dds_server_cert_path }}/server-key.pem -out {{ dds_server_cert_path }}/server.csr"
 
 - name: Create extfile
-  file:
-    state: touch 
-    path: "{{ dds_extfile }}" 
+  copy:
+    content: "subjectAltName = IP:{{ dds_host }}{{ ',IP:127.0.0.1' if dds_host != '127.0.0.1' }}"
+    dest: "{{ dds_server_cert_path }}/extfile.cnf"
 
-- name: Add alt name to extfile
-  lineinfile:
-    dest: "{{ dds_extfile }}" 
-    line: "subjectAltName = IP:{{ dds_host }},IP:127.0.0.1"
+- name: Create the server certificate
+  command: "openssl x509 -req -days 365 -sha256 -in {{ dds_server_cert_path }}/server.csr -CA {{ dds_client_cert_path }}/ca.pem -CAkey {{ dds_client_cert_path }}/ca-key.pem -CAcreateserial -out {{ dds_server_cert_path }}/server-cert.pem -extfile {{ dds_server_cert_path }}/extfile.cnf -passin env:PASSKEY"
+  environment:
+    PASSKEY: "{{ dds_passphrase }}"
 
-- name: Create the server certificate 
-  command: "openssl x509 -req -days 365 -sha256 -in {{ dds_temp_path }}/server.csr -CA {{ dds_temp_path }}/ca.pem -CAkey {{ dds_temp_path }}/ca-key.pem -CAcreateserial -out {{ dds_temp_path}}/server-cert.pem -extfile {{ dds_temp_path}}/extfile.cnf -passin file:{{ dds_passphrase_file }}"
-
-- name: Check that the server cert path exists
-  file:
-    state: directory
-    path: "{{ dds_server_cert_path }}"
-
-- name: Copy server certs
-  command: cp "{{ dds_temp_path }}/{{ item }}" "{{ dds_server_cert_path }}/."
-  with_items:
-    - ca.pem
-    - server-cert.pem
-    - server-key.pem
-
-- name: Set file permissions 
+- name: Set file permissions
   file:
     path: "{{ dds_server_cert_path }}/{{ item }}"
     mode: 0400
@@ -44,3 +29,16 @@
     - ca.pem
     - server-cert.pem
     - server-key.pem
+
+- name: Remove extfile and server.csr
+  file:
+    state: absent
+    path: "{{ dds_server_cert_path }}/{{ item }}"
+  with_items:
+  - server.csr
+  - extfile.cnf
+
+- name: Remove ca-key.pem
+  file:
+    path: "{{ dds_client_cert_path }}/ca-key.pem"
+    state: absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,39 +1,28 @@
 ---
 # main.yml
-
-- name: Create a tempdir
+- name: Check that the cert directories exists
   file:
     state: directory
-    path: "{{ dds_temp_path }}"   
-
-- name: Remove passphrase file, if it exists
-  file:
-    state: absent
-    path: "{{ dds_passphrase_file }}" 
-
-- name: Create passphrase file
-  file:
-    state: touch
-    path: "{{ dds_passphrase_file }}" 
-
-- name: Add passphrase to the file
-  lineinfile:
-    dest: "{{ dds_passphrase_file }}"
-    line: "{{ dds_passphrase }}" 
+    path: "{{ item }}"
+  with_items:
+  - "{{ dds_client_cert_path }}"
+  - "{{ dds_server_cert_path }}"
 
 - name: Generate ca-key.pem
-  command: "openssl genrsa -aes256 -passout file:{{ dds_passphrase_file }} -out {{ dds_temp_path }}/ca-key.pem 4096"
+  command: "openssl genrsa -aes256 -passout env:PASSKEY -out {{ dds_client_cert_path }}/ca-key.pem 4096"
+  environment:
+    PASSKEY: "{{ dds_passphrase }}"
 
-- name: Generate ca certificate   
-  command: "openssl req -new -x509 -days 365 -key {{ dds_temp_path }}/ca-key.pem -sha256 -out {{ dds_temp_path }}/ca.pem -passin file:{{ dds_passphrase_file }} -subj '/C={{ dds_country }}/ST={{dds_state }}>/L={{ dds_locality }}/O={{ dds_organization }}/CN={{ dds_common_name }}'"
+- name: Generate ca certificate contents
+  command: "openssl req -new -x509 -days 365 -key {{ dds_client_cert_path }}/ca-key.pem -sha256  -passin env:PASSKEY -subj '/C={{ dds_country }}/ST={{ dds_state }}>/L={{ dds_locality }}/O={{ dds_organization }}/CN={{ dds_common_name }}'"
+  register: dds_ca_pem
+  environment:
+    PASSKEY: "{{ dds_passphrase }}"
+  no_log: True
 
-- include: generate_server_certs.yml
 - include: generate_client_certs.yml
-
-- name: Remove the temp directory
-  file:
-    state: absent
-    path: "{{ dds_temp_path }}"
+- include: generate_server_certs.yml
+  become: true
 
 - name: Install shell script for setting DOCKER env vars
   template:
@@ -42,8 +31,9 @@
     mode: 0755
   when: dds_install_shell
 
-- name: Restart the docker daemon 
+- name: Restart the docker daemon
   service:
     name: docker
-    state: restarted  
+    state: restarted
+  become: true
   when: dds_restart_docker

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,0 @@
----
-dds_temp_path: "{{ dds_system_tmp }}/ansible_dds"
-dds_passphrase_file: "{{ dds_temp_path }}/passphrase.txt"
-dds_csr_form_file: "{{ dds_temp_path }}/csr_form.txt"
-dds_extfile: "{{ dds_temp_path }}/extfile.cnf"


### PR DESCRIPTION
The combination of `become: true` and
`~` for directory paths meant that all client certs
and setup scripts were installed in /root and owned
by root

Refactor so that only server cert generation done
as root - this also ensures that user certs are
installed with user ownership.

Remove reliance on temporary directory and generate
files in place

Use `-passin/-passout` with `env:PASSKEY` to avoid
need for passphrase file
