### PR TITLE
Correct key and certificate file rights

### DIFF
--- a/tasks/generate_client_certs.yml
+++ b/tasks/generate_client_certs.yml
@@ -36,11 +36,17 @@
     - cert.pem
     - key.pem
 
-- name: Set file permissions 
+- name: Set file permissions for keys
+  file:
+    path: "{{ dds_client_cert_path }}/{{ item }}"
+    mode: 0400
+  with_items:
+    - key.pem
+
+- name: Set file permissions for certificates
   file:
     path: "{{ dds_client_cert_path }}/{{ item }}"
     mode: 0444
   with_items:
     - ca.pem
     - cert.pem
-    - key.pem

--- a/tasks/generate_server_certs.yml
+++ b/tasks/generate_server_certs.yml
@@ -36,11 +36,17 @@
     - server-cert.pem
     - server-key.pem
 
-- name: Set file permissions 
+- name: Set file permissions for keys
   file:
     path: "{{ dds_server_cert_path }}/{{ item }}"
     mode: 0400
   with_items:
+    - server-key.pem
+
+- name: Set file permissions for certificates
+  file:
+    path: "{{ dds_server_cert_path }}/{{ item }}"
+    mode: 0444
+  with_items:
     - ca.pem
     - server-cert.pem
-    - server-key.pem

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,8 +24,22 @@
 - name: Generate ca-key.pem
   command: "openssl genrsa -aes256 -passout file:{{ dds_passphrase_file }} -out {{ dds_temp_path }}/ca-key.pem 4096"
 
+- name: Set ca-key.pem permissions
+  file:
+    path: "{{ dds_temp_path }}/{{ item }}"
+    mode: 0400
+  with_items:
+    - ca-key.pem
+
 - name: Generate ca certificate   
   command: "openssl req -new -x509 -days 365 -key {{ dds_temp_path }}/ca-key.pem -sha256 -out {{ dds_temp_path }}/ca.pem -passin file:{{ dds_passphrase_file }} -subj '/C={{ dds_country }}/ST={{dds_state }}>/L={{ dds_locality }}/O={{ dds_organization }}/CN={{ dds_common_name }}'"
+
+- name: Set CA certificate permissions
+  file:
+    path: "{{ dds_temp_path }}/{{ item }}"
+    mode: 0444
+  with_items:
+    - ca.pem
 
 - include: generate_server_certs.yml
 - include: generate_client_certs.yml


### PR DESCRIPTION
Response to issue: File permissions incorrect #2

* Split permission job into two jobs
* Set key files permission to 400
* Set certificate files to 444

Changes according to official Docker documentation  https://docs.docker.com/engine/security/https/#create-a-ca-server-and-client-keys-with-openssl